### PR TITLE
Use the SQL server function to get the current date for Changelog

### DIFF
--- a/Citrix.WEMSDK.psm1
+++ b/Citrix.WEMSDK.psm1
@@ -275,7 +275,7 @@ function New-ChangesLogEntry {
 
     if (-not $UserId) { $UserId = "[Citrix.WEMSDK] $($env:USERDOMAIN)\$($env:USERNAME)"}
 
-    $SQLQuery = "INSERT INTO VUEMChangesLog (IdSite,IdElement,UserId,ChangeType,ObjectName,ObjectType,ChangeDate,NewValue,ChangeDescription,Reserved01) VALUES ($($IdSite),$($IdElement),'$($UserId)','$($ChangeType)','$($ObjectName)','$($ObjectType)',GETDATE(),'$($NewValue)',"    
+    $SQLQuery = "INSERT INTO VUEMChangesLog (IdSite,IdElement,UserId,ChangeType,ObjectName,ObjectType,ChangeDate,NewValue,ChangeDescription,Reserved01) VALUES ($($IdSite),$($IdElement),'$($UserId)','$($ChangeType)','$($ObjectName)','$($ObjectType)',GETDATE(),'$($NewValue)',"
     if ($ChangeDescription) { 
         $SQLQuery += "'$($ChangeDescription)',"
     } else { 

--- a/Citrix.WEMSDK.psm1
+++ b/Citrix.WEMSDK.psm1
@@ -275,7 +275,8 @@ function New-ChangesLogEntry {
 
     if (-not $UserId) { $UserId = "[Citrix.WEMSDK] $($env:USERDOMAIN)\$($env:USERNAME)"}
 
-    $SQLQuery = "INSERT INTO VUEMChangesLog (IdSite,IdElement,UserId,ChangeType,ObjectName,ObjectType,ChangeDate,NewValue,ChangeDescription,Reserved01) VALUES ($($IdSite),$($IdElement),'$($UserId)','$($ChangeType)','$($ObjectName)','$($ObjectType)',GETDATE(),'$($NewValue)',"    if ($ChangeDescription) { 
+    $SQLQuery = "INSERT INTO VUEMChangesLog (IdSite,IdElement,UserId,ChangeType,ObjectName,ObjectType,ChangeDate,NewValue,ChangeDescription,Reserved01) VALUES ($($IdSite),$($IdElement),'$($UserId)','$($ChangeType)','$($ObjectName)','$($ObjectType)',GETDATE(),'$($NewValue)',"    
+    if ($ChangeDescription) { 
         $SQLQuery += "'$($ChangeDescription)',"
     } else { 
         $SQLQuery += "NULL,"

--- a/Citrix.WEMSDK.psm1
+++ b/Citrix.WEMSDK.psm1
@@ -275,8 +275,7 @@ function New-ChangesLogEntry {
 
     if (-not $UserId) { $UserId = "[Citrix.WEMSDK] $($env:USERDOMAIN)\$($env:USERNAME)"}
 
-    $SQLQuery = "INSERT INTO VUEMChangesLog (IdSite,IdElement,UserId,ChangeType,ObjectName,ObjectType,ChangeDate,NewValue,ChangeDescription,Reserved01) VALUES ($($IdSite),$($IdElement),'$($UserId)','$($ChangeType)','$($ObjectName)','$($ObjectType)','$(Get-Date)','$($NewValue)',"
-    if ($ChangeDescription) { 
+    $SQLQuery = "INSERT INTO VUEMChangesLog (IdSite,IdElement,UserId,ChangeType,ObjectName,ObjectType,ChangeDate,NewValue,ChangeDescription,Reserved01) VALUES ($($IdSite),$($IdElement),'$($UserId)','$($ChangeType)','$($ObjectName)','$($ObjectType)',GETDATE(),'$($NewValue)',"    if ($ChangeDescription) { 
         $SQLQuery += "'$($ChangeDescription)',"
     } else { 
         $SQLQuery += "NULL,"


### PR DESCRIPTION
Use the SQL server function to get the current date. It does not seem to work reliably via Powershell if the SQL server and PowerShell are not installed in English and the date from 'Get-Date' is first casted into a string by PowerShell.
Tested with: Citrix WEM 2112.1.0.1 and MS SQL Server 2019 (german)